### PR TITLE
AMPページ対応

### DIFF
--- a/plugins/AccessCounter/AccessCounter.pl
+++ b/plugins/AccessCounter/AccessCounter.pl
@@ -134,6 +134,7 @@ sub _add_tracking_tag
 
     return unless $args{blog} && $plugin->get_config_value('tracking', 'blog:' . $args{blog}->id);
     return unless $args{entry};
+    return if $args{Template}->name =~ /AMP/;
 
     my $path  = MT::ConfigMgr->instance->CGIPath;
        $path .= '/' unless $path =~ m!/$!;


### PR DESCRIPTION
"AMP" とタイトルに記載されているテンプレートに<script>タグを追加しないように致しました。
(AMPページだけにアクセス数はカウントされません)